### PR TITLE
(Openstack) Dumbing down the appCacheBackedMutliSelect.

### DIFF
--- a/app/scripts/modules/openstack/common/cacheBackedMultiSelect.template.html
+++ b/app/scripts/modules/openstack/common/cacheBackedMultiSelect.template.html
@@ -10,7 +10,7 @@
     </ui-select>
   </div>
   <div class="col-md-1 sm-label-left">
-    <a href="" ng-click="cache.refresh()" uib-tooltip-template="refreshTooltipTemplate">
+    <a href="" ng-click="forceRefreshCache()" uib-tooltip-template="refreshTooltipTemplate">
       <span class="glyphicon glyphicon-refresh" ng-class="{'glyphicon-spinning':cache.loading}"></span>
     </a>
   </div>

--- a/app/scripts/modules/openstack/common/cacheBackedMultiSelectField.directive.js
+++ b/app/scripts/modules/openstack/common/cacheBackedMultiSelectField.directive.js
@@ -4,58 +4,51 @@ import _ from 'lodash';
 
 let angular = require('angular');
 
-module.exports = angular.module('spinnaker.openstack.appCacheBackedMultiSelectField.directive', [])
-  .directive('osAppCacheBackedMultiSelectField', function () {
+module.exports = angular.module('spinnaker.openstack.cacheBackedMultiSelectField.directive', [])
+  .directive('osCacheBackedMultiSelectField', function () {
     return {
       restrict: 'E',
-      templateUrl: require('./appCacheBackedMultiSelect.template.html'),
+      templateUrl: require('./cacheBackedMultiSelect.template.html'),
       scope: {
-        cacheKey: '@',
-        filter: '<?',
+        cache: '=',
+        refreshCache: '=',
         label: '@',
         model: '=',
         onChange: '&',
         required: '<?'
       },
       link: function(scope) {
-        var app = scope.$parent.application;
-        var cache = app[scope.cacheKey];
-
         _.defaults(scope, {
           //wrap selectedOptions to work around issue with ng-model where binding only works if the model is a property of an object
           // (probably fixed in newer versions of AngularJS)
           state: { selectedOptions: scope.model },
           refreshTooltipLabel: scope.label,
           refreshTooltipTemplate: require('./cacheRefresh.tooltip.html'),
-          filter: {},
-          cache: cache,
+          cache: [],
           required: false,
+          forceRefreshCache: _.isFunction(scope.refreshCache) ? scope.refreshCache : function() {},
 
           onSelectionsChanged: function() {
             //Hack to work around bug in ui-select where selected values re-appear in the drop-down
             scope.state.selectedOptions = _.uniq(scope.state.selectedOptions);
             scope.model = scope.state.selectedOptions;
             if( scope.onChange ) {
-              var args = {};
-              args[scope.cacheKey] = scope.model;
+              var args = { selection: scope.model };
               scope.onChange(args);
             }
           }
         });
 
         function updateOptions() {
-          scope.options = _.chain(cache.data)
-            .filter(scope.filter)
-            .sortBy(function(o) { o.name; })
+          scope.options = _.chain(scope.cache)
+            .sortBy('name')
             .value();
         }
 
-        cache.onRefresh(scope, updateOptions);
-        scope.$watch('filter', updateOptions, true);
+        scope.$watch('cache', updateOptions);
         scope.$watch('model', function(model) {
           scope.state.selectedOptions = model;
         });
-
         updateOptions();
       }
     };

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/interface.html
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/interface.html
@@ -2,10 +2,10 @@
   <div class="modal-body">
     <network-select-field model="loadBalancer.networkId" help-key="openstack.loadBalancer.network" read-only="!isNew"></network-select-field>
 
-    <os-app-cache-backed-multi-select-field label="Security Groups"
-                                            cache-key="securityGroups"
-                                            filter="filter"
+    <os-cache-backed-multi-select-field label="Security Groups"
+                                            cache="allSecurityGroups"
+                                            refresh-cache="updateSecurityGroups"
                                             required="true"
-                                            model="loadBalancer.securityGroups"></os-app-cache-backed-multi-select-field>
+                                            model="loadBalancer.securityGroups"></os-cache-backed-multi-select-field>
   </div>
 </ng-form>

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.js
@@ -18,15 +18,14 @@ module.exports = angular.module('spinnaker.loadBalancer.openstack.create.control
     require('../../../subnet/subnetSelectField.directive.js'),
     require('../../../network/networkSelectField.directive.js'),
     require('../../../common/isolateForm.directive.js'),
+    require('core/securityGroup/securityGroup.read.service.js')
   ])
   .controller('openstackUpsertLoadBalancerController', function($scope, $uibModalInstance, $state,
                                                                 application, loadBalancer, isNew, loadBalancerReader,
                                                                 accountService, openstackLoadBalancerTransformer,
-                                                                loadBalancerWriter, taskMonitorService) {
+                                                                loadBalancerWriter, taskMonitorService, securityGroupReader) {
     var ctrl = this;
     $scope.isNew = isNew;
-    $scope.application = application;
-
     $scope.application = application;
 
     $scope.pages = {
@@ -51,6 +50,11 @@ module.exports = angular.module('spinnaker.loadBalancer.openstack.create.control
       { label: 'Least Connections', value: 'LEAST_CONNECTIONS' },
       { label: 'Source IP', value: 'SOURCE_IP' }
     ];
+
+    $scope.allSecurityGroups = [];
+    $scope.$watch('loadBalancer.account', updateSecurityGroups);
+    $scope.$watch('loadBalancer.region', updateSecurityGroups);
+    updateSecurityGroups();
 
     // initialize controller
     if (loadBalancer) {
@@ -132,6 +136,19 @@ module.exports = angular.module('spinnaker.loadBalancer.openstack.create.control
       $scope.existingLoadBalancerNames = _.flatten(_.map(allLoadBalancerNames[$scope.loadBalancer.account || ''] || []));
     }
 
+    function updateSecurityGroups() {
+      var account = _.get($scope, ['loadBalancer', 'account']);
+      var region = _.get($scope, ['loadBalancer', 'region']);
+      if (!account || !region) {
+        $scope.allSecurityGroups = [];
+      }
+      var securityGroups = securityGroupReader.getAllSecurityGroups()
+        .then(function(securityGroups) {
+          var filtered = _.get(securityGroups, [account, 'openstack', region], []);
+          $scope.allSecurityGroups = _.chain(filtered).sortBy('name').value();
+        });
+    }
+
     // Controller API
     this.updateName = function() {
       if (!isNew) {
@@ -177,17 +194,6 @@ module.exports = angular.module('spinnaker.loadBalancer.openstack.create.control
     this.prependForwardSlash = (text) => {
       return text && text.indexOf('/') !== 0 ? `/${text}` : text;
     };
-
-    function updateFilter() {
-      $scope.filter = {
-        account: $scope.loadBalancer.account,
-        region: $scope.loadBalancer.region
-      };
-    }
-
-    $scope.$watch('loadBalancer.account', updateFilter);
-    $scope.$watch('loadBalancer.region', updateFilter);
-    updateFilter();
 
     this.removeListener = function(index) {
       $scope.loadBalancer.listeners.splice(index, 1);

--- a/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
+++ b/app/scripts/modules/openstack/loadBalancer/configure/wizard/upsert.controller.spec.js
@@ -93,6 +93,7 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
     this.mockLoadBalancerReader = addDeferredMock({}, 'listLoadBalancers');
     this.mockAccountService = addDeferredMock({}, 'listAccounts');
     this.mockLoadBalancerWriter = addDeferredMock({}, 'upsertLoadBalancer');
+    this.mockSecurityGroupReader = addDeferredMock({}, 'getAllSecurityGroups');
     this.mockTaskMonitor = {
       submit: jasmine.createSpy('taskMonitor.submit')
     };
@@ -114,7 +115,8 @@ describe('Controller: openstackCreateLoadBalancerCtrl', function () {
         loadBalancerReader: this.mockLoadBalancerReader,
         accountService: this.mockAccountService,
         loadBalancerWriter: this.mockLoadBalancerWriter,
-        taskMonitorService: this.mockTaskMonitorService
+        taskMonitorService: this.mockTaskMonitorService,
+        securityGroupReader: this.mockSecurityGroupReader,
       });
     };
   }));

--- a/app/scripts/modules/openstack/serverGroup/configure/serverGroupConfiguration.service.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/serverGroupConfiguration.service.js
@@ -34,7 +34,7 @@ module.exports = angular.module('spinnaker.openstack.serverGroup.configure.confi
     function configureCommand(application, command) {
       return $q.all({
         credentialsKeyedByAccount: accountService.getCredentialsKeyedByAccount('openstack'),
-        securityGroups: securityGroupReader.loadSecurityGroups(),
+        securityGroups: securityGroupReader.getAllSecurityGroups(),
         loadBalancers: loadBalancerReader.loadLoadBalancers(application.name),
         userDataTypes: $q.when(angular.copy(userDataTypes))
       }).then(function(backingData) {
@@ -42,6 +42,7 @@ module.exports = angular.module('spinnaker.openstack.serverGroup.configure.confi
         backingData.accounts = _.keys(backingData.credentialsKeyedByAccount);
         backingData.filtered = {};
         command.backingData = backingData;
+        backingData.filtered.securityGroups = getRegionalSecurityGroups(command);
 
         if(_.get(command, 'loadBalancers').length) {
           // verify all load balancers are accounted for; otherwise, try refreshing load balancers cache
@@ -85,7 +86,7 @@ module.exports = angular.module('spinnaker.openstack.serverGroup.configure.confi
     }
 
     function getRegionalSecurityGroups(command) {
-      var newSecurityGroups = command.backingData.securityGroups[command.credentials] || { openstack: {}};
+      var newSecurityGroups = _.get(command, ['backingData', 'securityGroups', command.credentials, 'openstack'], {});
       return _.chain(newSecurityGroups[command.region])
         .sortBy('name')
         .value();

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/Clone.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/Clone.controller.js
@@ -49,7 +49,7 @@ module.exports = angular.module('spinnaker.openstack.serverGroup.configure.clone
     function configureCommand() {
       serverGroupCommand.viewState.contextImages = $scope.contextImages;
       $scope.contextImages = null;
-      openstackServerGroupConfigurationService.configureCommand(application, serverGroupCommand).then(function () {
+      openstackServerGroupConfigurationService.configureCommand(application, serverGroupCommand).then(function() {
         $scope.state.loaded = true;
         initializeWizardState();
         initializeWatches();

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/access/AccessSettings.controller.js
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/access/AccessSettings.controller.js
@@ -5,19 +5,31 @@ let angular = require('angular');
 module.exports = angular.module('spinnaker.serverGroup.configure.openstack.accessSettings', [
   require('angular-ui-router'),
   require('angular-ui-bootstrap'),
-  require('../../../../common/appCacheBackedMultiSelectField.directive.js'),
+  require('../../../../common/cacheBackedMultiSelectField.directive.js'),
 ]).controller('openstackServerGroupAccessSettingsCtrl', function($scope, loadBalancerReader, securityGroupReader, networkReader, v2modalWizardService) {
 
-  function updateFilter() {
-    $scope.filter = {
+  // Loads all load balancers in the current application, region, and account
+  $scope.updateLoadBalancers = function() {
+    var filter = {
       account: $scope.command.credentials,
       region: $scope.command.region
     };
-  }
+    $scope.application.loadBalancers.refresh();
+    $scope.allLoadBalancers = _.filter($scope.application.loadBalancers.data, filter);
+  };
+  $scope.$watch('command.credentials', $scope.updateLoadBalancers);
+  $scope.$watch('command.region', $scope.updateLoadBalancers);
+  $scope.$watch('application.loadBalancers', $scope.updateLoadBalancers);
+  $scope.updateLoadBalancers();
 
-  $scope.$watch('command.credentials', updateFilter);
-  $scope.$watch('command.region', updateFilter);
-  updateFilter();
+  // Loads all security groups in the current region and account
+  $scope.updateSecurityGroups = function() {
+    $scope.allSecurityGroups = getSecurityGroups();
+  };
+  // The backingData the getSecurityGroups gets resolved after the form is loaded, so lets watch it
+  $scope.$watch(function() {
+    return _.map(getSecurityGroups(), 'id').join();
+  }, $scope.updateSecurityGroups);
 
   $scope.$watch('accessSettings.$valid', function(newVal) {
     if (newVal) {
@@ -27,5 +39,9 @@ module.exports = angular.module('spinnaker.serverGroup.configure.openstack.acces
       v2modalWizardService.markIncomplete('access-settings');
     }
   });
+
+  function getSecurityGroups() {
+    return _.get($scope.command.backingData, 'filtered.securityGroups', []);
+  }
 
 });

--- a/app/scripts/modules/openstack/serverGroup/configure/wizard/access/accessSettings.html
+++ b/app/scripts/modules/openstack/serverGroup/configure/wizard/access/accessSettings.html
@@ -16,17 +16,17 @@
       </div>
     </div>
 
-    <os-app-cache-backed-multi-select-field label="Load Balancers"
-                                            cache-key="loadBalancers"
-                                            filter="filter"
+    <os-cache-backed-multi-select-field label="Load Balancers"
+                                            cache="allLoadBalancers"
+                                            refresh-cache="updateLoadBalancers"
                                             required="false"
-                                            model="command.loadBalancers"></os-app-cache-backed-multi-select-field>
+                                            model="command.loadBalancers"></os-cache-backed-multi-select-field>
 
-    <os-app-cache-backed-multi-select-field label="Security Groups"
-                                            cache-key="securityGroups"
-                                            filter="filter"
+    <os-cache-backed-multi-select-field label="Security Groups"
+                                            cache="allSecurityGroups"
+                                            refresh-cache="updateSecurityGroups"
                                             required="true"
-                                            model="command.securityGroups"></os-app-cache-backed-multi-select-field>
+                                            model="command.securityGroups"></os-cache-backed-multi-select-field>
 
     <div class="form-group">
       <div class="col-md-5 sm-label-left">
@@ -61,4 +61,3 @@
     </ng-form>
   </div>
 </div>
-


### PR DESCRIPTION
Need different caches for load balancers than security groups. Passing
in an explicit cache instead of having the directive read the cache via
cache key from the application list.